### PR TITLE
Update devcontainer.json - use ubuntu 22.04

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Terraform Azure Workshop",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
   "features": {
     "ghcr.io/devcontainers/features/terraform:1": {
       "version": "1.11.4"


### PR DESCRIPTION
Latest Ubuntu causes an issue with downloading the GPG key (https://github.com/devcontainers/features/issues/1418)

Downgrading to 22.04 shaves about 1 minute of the start time of the devcontainer